### PR TITLE
implement a stuff

### DIFF
--- a/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
+++ b/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
@@ -165,6 +165,21 @@ class Expressions {
         return evaluator.eval(parse(expression))
     }
 
+	/**
+	 * eval an expression then round it with {@link Evaluator#mathContext} and call toEngineeringString <br>
+	 * if error will return message from Throwable
+	 * @param expression String
+	 * @return String
+	 */
+    fun evalToString(expression: String): String {
+        return try {
+            evaluator.eval(parse(expression)).round(evaluator.mathContext).stripTrailingZeros()
+                    .toEngineeringString()
+        }catch (e:Throwable){
+            e.cause?.message ?: e.message ?: "unknown error"
+        }
+    }
+
     private fun parse(expression: String): Expr {
         return parse(scan(expression))
     }

--- a/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
+++ b/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
@@ -126,7 +126,7 @@ class Expressions {
     }
 
     fun define(name: String, value: Double): Expressions {
-        define(name.toLowerCase(), value.toString())
+        define(name, value.toString())
 
         return this
     }

--- a/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
+++ b/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
@@ -126,7 +126,7 @@ class Expressions {
     }
 
     fun define(name: String, value: Double): Expressions {
-        define(name, value.toString())
+        define(name.toLowerCase(), value.toString())
 
         return this
     }

--- a/src/main/kotlin/com/github/keelar/exprk/internal/Evaluator.kt
+++ b/src/main/kotlin/com/github/keelar/exprk/internal/Evaluator.kt
@@ -17,13 +17,13 @@ internal class Evaluator() : ExprVisitor<BigDecimal> {
     }
 
     fun define(name: String, expr: Expr): Evaluator {
-        define(name, eval(expr))
+        define(name.toLowerCase(), eval(expr))
 
         return this
     }
 
     fun addFunction(name: String, function: Function): Evaluator {
-        functions += name to function
+        functions += name.toLowerCase() to function
 
         return this
     }
@@ -87,7 +87,7 @@ internal class Evaluator() : ExprVisitor<BigDecimal> {
 
     override fun visitCallExpr(expr: CallExpr): BigDecimal {
         val name = expr.name
-        val function = functions[name] ?:
+        val function = functions[name.toLowerCase()] ?:
                 throw ExpressionException("Undefined function '$name'")
 
         return function.call(expr.arguments.map { eval(it) })
@@ -100,7 +100,7 @@ internal class Evaluator() : ExprVisitor<BigDecimal> {
     override fun visitVariableExpr(expr: VariableExpr): BigDecimal {
         val name = expr.name.lexeme
 
-        return variables[name] ?:
+        return variables[name.toLowerCase()] ?:
                 throw ExpressionException("Undefined variable '$name'")
     }
 

--- a/src/main/kotlin/com/github/keelar/exprk/internal/Scanner.kt
+++ b/src/main/kotlin/com/github/keelar/exprk/internal/Scanner.kt
@@ -63,13 +63,23 @@ internal class Scanner(private val source: String,
         }
     }
 
+    private fun isDigit(char: Char,
+                        previousChar: Char = '\u0000',
+                        nextChar: Char = '\u0000'): Boolean {
+        return char.isDigit() || when (char) {
+            '.'      -> true
+            'e', 'E' -> previousChar.isDigit() && (nextChar.isDigit() || nextChar == '+' || nextChar == '-')
+            '+', '-' -> (previousChar == 'e' || previousChar == 'E') && nextChar.isDigit()
+            else     -> false
+        }
+    }
+
     private fun number() {
         while (peek().isDigit()) advance()
 
-        if (peek() == '.' && peekNext().isDigit()) {
+        if (isDigit(peek(), peekPrevious(), peekNext())) {
             advance()
-
-            while (peek().isDigit()) advance()
+            while (isDigit(peek(), peekPrevious(), peekNext())) advance()
         }
 
         val value = source
@@ -94,6 +104,8 @@ internal class Scanner(private val source: String,
             source[current]
         }
     }
+
+    private fun peekPrevious(): Char = if (current > 0) source[current - 1] else '\u0000'
 
     private fun peekNext(): Char {
         return if (current + 1 >= source.length) {
@@ -124,6 +136,6 @@ internal class Scanner(private val source: String,
             || this in 'A'..'Z'
             || this == '_'
 
-    private fun Char.isDigit() = this in '0'..'9'
+    private fun Char.isDigit() = this == '.' || this in '0'..'9'
 
 }

--- a/src/test/kotlin/com/github/keelar/exprk/TestExpressions.kt
+++ b/src/test/kotlin/com/github/keelar/exprk/TestExpressions.kt
@@ -13,4 +13,23 @@ class TestExpressions {
         expr.define("SCIVAL", scival)
         assertEquals(scival.toPlainString(), expr.eval("SCIVAL").toPlainString())
     }
+
+    @Test
+    fun `test Scanner will scan scientific form correctly`(){
+        val expr = Expressions()
+        assertEquals(BigDecimal("1e+7").toPlainString(), expr.eval("1E+7").toPlainString())
+        assertEquals(BigDecimal("1e-7").toPlainString(), expr.eval("1E-7").toPlainString())
+        assertEquals(BigDecimal(".101e+2").toPlainString(), expr.eval(".101e+2").toPlainString())
+        assertEquals(BigDecimal(".123e2").toPlainString(), expr.eval(".123e2").toPlainString())
+        assertEquals(BigDecimal("3212.123e-2").toPlainString(), expr.eval("3212.123e-2").toPlainString())
+    }
+
+    @Test
+    fun `test normal expression`() {
+        val expr = Expressions()
+        assertEquals(BigDecimal(".123e2").add(BigDecimal("3212.123e-2")).toPlainString(),
+                     expr.eval(".123e2+3212.123e-2").toPlainString())
+        assertEquals(BigDecimal("1e+7").minus(BigDecimal("52132e-2")).toPlainString(),
+                     expr.eval("1E+7-52132e-2").toPlainString())
+    }
 }

--- a/src/test/kotlin/com/github/keelar/exprk/TestExpressions.kt
+++ b/src/test/kotlin/com/github/keelar/exprk/TestExpressions.kt
@@ -32,4 +32,21 @@ class TestExpressions {
         assertEquals(BigDecimal("1e+7").minus(BigDecimal("52132e-2")).toPlainString(),
                      expr.eval("1E+7-52132e-2").toPlainString())
     }
+
+    @Test
+    fun `test is functions are ignore case`(){
+        val expr = Expressions()
+        assertEquals(listOf(BigDecimal.ONE.negate(), BigDecimal.ZERO, BigDecimal.ONE).min(),
+                     expr.eval("mIN(-1,0,1)"))
+
+        assertEquals(listOf(BigDecimal.ONE.negate(), BigDecimal.ZERO, BigDecimal.ONE).max(),
+                     expr.eval("MaX(-1,0,1)"))
+    }
+
+    @Test
+    fun `test is variables are ignore case`(){
+        val expr = Expressions()
+        assertEquals(BigDecimal(Math.PI.toString()), expr.eval("pI"))
+        assertEquals(BigDecimal(Math.E.toString()), expr.eval("E"))
+    }
 }


### PR DESCRIPTION
+ scanner now accept scientific number 
   > example `1e2` is `100`, `1e+2` is `100`, `1e-2` is `0.01`, `.01` is `0.1`
+ make function name and variable name case insensitive
   > `define("PI",Math.PI)` can be use as `eval("Pi")`, `eval("pI")`, `eval("pi")`
+ add evalToString method
  > normal if we `eval("1/0")` will throw `java.lang.ArithmeticException: Division by zero` but `evalToString("1/0")` will return `Division by zero` without any exception
+ add test
  - test Scanner will scan scientific form correctly
    > assertEquals(BigDecimal("3212.123e-2").toPlainString(), expr.eval("3212.123e-2").toPlainString())
  - test normal expression
    > assertEquals(BigDecimal(".123e2").add(BigDecimal("3212.123e-2")).toPlainString(). expr.eval(".123e2+3212.123e-2").toPlainString())
  - test is functions are ignore case
    > assertEquals(listOf(BigDecimal.ONE.negate(), BigDecimal.ZERO, BigDecimal.ONE).min(),expr.eval("mIN(-1,0,1)"))
  - test is variables are ignore case
    > assertEquals(BigDecimal(Math.PI.toString()), expr.eval("pI"))