### PR TITLE
Fix exception message of pre-defined functions init codes on Expression class

### DIFF
--- a/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
+++ b/src/main/kotlin/com/github/keelar/exprk/Expressions.kt
@@ -40,7 +40,7 @@ class Expressions {
         evaluator.addFunction("floor", object : Function() {
             override fun call(arguments: List<BigDecimal>): BigDecimal {
                 if (arguments.size != 1) throw ExpressionException(
-                        "abs requires one argument")
+                        "floor requires one argument")
 
                 return arguments.first().setScale(0, RoundingMode.FLOOR)
             }
@@ -49,7 +49,7 @@ class Expressions {
         evaluator.addFunction("ceil", object : Function() {
             override fun call(arguments: List<BigDecimal>): BigDecimal {
                 if (arguments.size != 1) throw ExpressionException(
-                        "abs requires one argument")
+                        "ceil requires one argument")
 
                 return arguments.first().setScale(0, RoundingMode.CEILING)
             }


### PR DESCRIPTION
I found and fix few minor issue of pre-defined function initialize codes.
Input validation exception message of `floor` and `ceil` has typo.